### PR TITLE
Support null navigation collection   in a new entity

### DIFF
--- a/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
@@ -13,10 +13,9 @@
     <PackageReleaseNotes>simple update method that will help you to do a full update to an aggregate graph with all related entities in it.
 the update method will take the loaded aggregate entity from the DB and the passed one that may come from the API layer. Internally the method will update just the eager loaded entities in the aggregate "The included entities"</PackageReleaseNotes>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <AssemblyVersion>1.0.7.0</AssemblyVersion>
-    <FileVersion>1.0.7.0</FileVersion>
-    <Version>1.0.7</Version>
-    <PackageLicenseFile></PackageLicenseFile>
+    <AssemblyVersion>1.0.8.0</AssemblyVersion>
+    <FileVersion>1.0.8.0</FileVersion>
+    <Version>1.0.8</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UnitTests/GraphUpdateTests.cs
+++ b/src/UnitTests/GraphUpdateTests.cs
@@ -292,7 +292,7 @@ namespace UnitTests
 				'Mersin'
 					]
             }");
-             var dbSchool = dbContext.Schools
+            var dbSchool = dbContext.Schools
                 .Include(s => s.House)
                 .FirstOrDefault();
 

--- a/src/UnitTests/GraphUpdateTests.cs
+++ b/src/UnitTests/GraphUpdateTests.cs
@@ -292,8 +292,7 @@ namespace UnitTests
 				'Mersin'
 					]
             }");
-
-            var dbSchool = dbContext.Schools
+             var dbSchool = dbContext.Schools
                 .Include(s => s.House)
                 .FirstOrDefault();
 
@@ -319,8 +318,13 @@ namespace UnitTests
         [Test]
         public void S0061_Set_Classes_From_The_School_Null_Should_Make_The_Classes_Empty()
         {
-            dbContext.InsertUpdateOrDeleteGraph(school, null);//Initialise school to have dbSchool not null
-            dbContext.SaveChanges();
+            var dbSchoolInitial = dbContext.Schools.FirstOrDefault();
+            if (dbSchoolInitial == null)
+            {
+                dbContext.InsertUpdateOrDeleteGraph(school, null); //Initialise school to have dbSchool not null
+                dbContext.SaveChanges();
+            }
+
             var dbSchool = dbContext.Schools
                 .Include(s => s.Classes)
                 .FirstOrDefault();

--- a/src/UnitTests/GraphUpdateTests.cs
+++ b/src/UnitTests/GraphUpdateTests.cs
@@ -313,7 +313,44 @@ namespace UnitTests
 
             Assert.Null(updatedDbSchool.House);
         }
+        /// <summary>
+        /// Update an Aggregate by deleting one-to-one navigation property
+        /// </summary>
+        [Test]
+        public void S0061_Set_Classes_From_The_School_Null_Should_Make_The_Classes_Empty()
+        {
+            dbContext.InsertUpdateOrDeleteGraph(school, null);//Initialise school to have dbSchool not null
+            dbContext.SaveChanges();
+            var dbSchool = dbContext.Schools
+                .Include(s => s.Classes)
+                .FirstOrDefault();
 
+            Assert.IsTrue(dbSchool.Classes.Count>0);
+
+            var updatedSchool = JsonConvert.DeserializeObject<School>(@"
+            {
+				'Id': 1,
+				'Name': 'The First',
+				'Type': 1,
+            }");
+            updatedSchool.Classes=null;
+
+            // Act
+            dbContext.InsertUpdateOrDeleteGraph(updatedSchool, dbSchool);
+            dbContext.SaveChanges();
+
+            var updatedDbSchool = dbContext.Schools
+                .Include(s => s.Classes)
+                .FirstOrDefault();
+
+            Console.WriteLine(JsonConvert.SerializeObject(updatedDbSchool, new JsonSerializerSettings()
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+                Formatting = Formatting.Indented,
+            }));
+
+            Assert.IsTrue(updatedDbSchool.Classes.Count==0);
+        }
 
         /// <summary>
         /// Update an inner Entity in the Aggregate should not affect the other sub Entities as they're not included in the changes


### PR DESCRIPTION
Current code throws an exception if in NewEntity navigation collection is null.
Added corresponding test S0061_Set_Classes_From_The_School_Null_Should_Make_The_Classes_Empty