### PR TITLE
Add support for .net 8 through 10 Expand .NET version support to net8.0-net10.0

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -23,7 +23,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore
         run: dotnet restore src/EFCore.UpdateGraph.slnx
@@ -52,7 +55,10 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
 
       - name: Restore package project
         run: dotnet restore src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Digital Wink Entity Framework Extensions
-In this simple project we're going to expose the helper extension methods that we're using in our company.
-and as a starting point we'll start with the Graph update method.
+In this simple project we're going to expose the helper extension methods that we're using in our company, and as a starting point we'll start with the Graph update method.
 We'll update the [Nuget Package](https://www.nuget.org/packages/Diwink.Extensions.EntityFrameworkCore/) whenever we have a new version.
 
 ## Entity Framework Core Simple Graph Update
@@ -12,7 +11,7 @@ Internally the method will update just the eager loaded entities in the aggregat
 
 ## Support (.NET 8-10, EF Core 9-10)
 
-The project was rebuilt to ships new `net10.x.x` assets, so the package
+The project now ships `net8.0`, `net9.0`, and `net10.0` assets, so the package
 supports .NET 8.x through .NET 10.x and EF Core 9.x through 10.x while keeping
 the same explicit, contract-driven relationship semantics.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Digital Wink Entity Framework Extensions
-In this simple project we're going to expose the helper extenasion methods that we're using in our company.
-and as a starting point we'll start witht the Graph update method.
+In this simple project we're going to expose the helper extension methods that we're using in our company.
+and as a starting point we'll start with the Graph update method.
 We'll update the [Nuget Package](https://www.nuget.org/packages/Diwink.Extensions.EntityFrameworkCore/) whenever we have a new version.
 
 ## Entity Framework Core Simple Graph Update
@@ -9,24 +9,12 @@ It's a simple update method that will help you to do a full update to an aggrega
 the update method will take the loaded aggregate entity from the DB and the passed one that may come from the API layer.
 Internally the method will update just the eager loaded entities in the aggregate "The included entities"
 
-```csharp
-var updatedSchool = mapper.Map<School>(apiModel);
 
-var dbSchool = dbContext.Schools
-    .Include(s => s.Classes)
-    .ThenInclude(s => s.Students)
-    .FirstOrDefault();
+## Support (.NET 8-10, EF Core 9-10)
 
-dbContext.InsertUpdateOrDeleteGraph(updatedSchool, dbSchool);
-
-dbContext.SaveChanges();
-
-```
-
-## v2 Rebuild (EF Core 10+)
-
-The v2 rebuild (`src/`) targets .NET 10 and EF Core 10.x with explicit,
-contract-driven relationship semantics.
+The project was rebuilt to ships new `net10.x.x` assets, so the package
+supports .NET 8.x through .NET 10.x and EF Core 9.x through 10.x while keeping
+the same explicit, contract-driven relationship semantics.
 
 ### Supported Relationship Patterns
 
@@ -46,7 +34,7 @@ contract-driven relationship semantics.
 | Mixed supported + unsupported mutations | `PartialMutationNotAllowedException` |
 | Unsupported relationship unchanged | Silently skipped |
 
-### v2 Usage
+### Usage
 
 ```csharp
 var updated = BuildDesiredState(); // detached graph

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <EfCore9Version>[9.0.14,10.0.0)</EfCore9Version>
     <EfCore10Version>[10.0.5,11.0.0)</EfCore10Version>
   </PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <EfCore9Version>[9.0.14,10.0.0)</EfCore9Version>
+    <EfCore10Version>[10.0.5,11.0.0)</EfCore10Version>
+  </PropertyGroup>
+</Project>

--- a/src/Diwink.Extensions.EntityFrameworkCore.TestModel/Diwink.Extensions.EntityFrameworkCore.TestModel.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore.TestModel/Diwink.Extensions.EntityFrameworkCore.TestModel.csproj
@@ -9,6 +9,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore9Version)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore10Version)" />
   </ItemGroup>

--- a/src/Diwink.Extensions.EntityFrameworkCore.TestModel/Diwink.Extensions.EntityFrameworkCore.TestModel.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore.TestModel/Diwink.Extensions.EntityFrameworkCore.TestModel.csproj
@@ -1,13 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore10Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Diwink.Extensions.EntityFrameworkCore.Tests.Integration/Diwink.Extensions.EntityFrameworkCore.Tests.Integration.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore.Tests.Integration/Diwink.Extensions.EntityFrameworkCore.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,12 +10,20 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore9Version)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EfCore10Version)" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCore10Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Diwink.Extensions.EntityFrameworkCore.Tests.Unit/Diwink.Extensions.EntityFrameworkCore.Tests.Unit.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore.Tests.Unit/Diwink.Extensions.EntityFrameworkCore.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
@@ -10,10 +10,17 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0' Or '$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(EfCore10Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
 
     <PackageId>Diwink.Extensions.EntityFrameworkCore</PackageId>
-    <Version>10.0.0</Version>
+    <Version>10.0.1</Version>
     <Authors>Wahid Bitar</Authors>
     <Company>Digital Wink</Company>
     <Description>Simple graph update extension for Entity Framework Core 9.x and 10.x on .NET 8.x through 10.x</Description>

--- a/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -9,13 +8,17 @@
     <Version>10.0.0</Version>
     <Authors>Wahid Bitar</Authors>
     <Company>Digital Wink</Company>
-    <Description>Simple graph update extension for Entity Framework Core targeting EF Core 10+</Description>
+    <Description>Simple graph update extension for Entity Framework Core 9.x and 10.x on .NET 8.x through 10.x</Description>
     <RepositoryUrl>https://github.com/WahidBitar/EF-Core-Simple-Graph-Update.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EfCore10Version)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
+++ b/src/Diwink.Extensions.EntityFrameworkCore/Diwink.Extensions.EntityFrameworkCore.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EfCore9Version)" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EfCore9Version)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="$(EfCore10Version)" />
   </ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded platform support to .NET 8–10 with EF Core 9.x–10.x compatibility; package metadata updated for multi-target releases.
* **Documentation**
  * Fixed typos, removed an example snippet, renamed the usage heading, and updated the supported versions section.
* **Chores**
  * Centralized build properties for multi-targeting and EF Core version ranges; projects adjusted to multi-target and CI updated to run against multiple .NET SDKs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->